### PR TITLE
Update SentryDefaultProjectile.java

### DIFF
--- a/java/me/dawars/CraftingPillars/api/sentry/SentryDefaultProjectile.java
+++ b/java/me/dawars/CraftingPillars/api/sentry/SentryDefaultProjectile.java
@@ -20,9 +20,11 @@ public abstract class SentryDefaultProjectile implements ISentryBehaviorItem
 	@Override
 	public final ItemStack dispense(IBlockSource blockSource,  EntityLivingBase target, EntityLivingBase owner, ItemStack item)
 	{
-		this.playSound(blockSource);
-		this.spawnParticles(blockSource);
-		this.spawnEntity(blockSource, target, owner, item);
+		if(target!=null && owner!=null) {
+			this.playSound(blockSource);
+			this.spawnParticles(blockSource);
+			this.spawnEntity(blockSource, target, owner, item);
+		}
 		return item;
 	}
 


### PR DESCRIPTION
Attempt to fix NullPointerException that occurs when Sentry Pillars are used by The Elysium mod in EntityFireballProjectile class.